### PR TITLE
Feat/notification

### DIFF
--- a/scripts/discord_notify.rb
+++ b/scripts/discord_notify.rb
@@ -279,6 +279,7 @@ class DiscordNotifier
 
   def shutdown
     return if @shutdown_sent
+    return if !@rcon
 
     @shutdown_sent = true
     @webhook.send({

--- a/scripts/discord_notify.rb
+++ b/scripts/discord_notify.rb
@@ -40,7 +40,7 @@ class DiscordWebhook
   def send(payload, log_message: nil)
     puts "[Discord] #{log_message || payload.to_json}"
 
-    return unless @enabled
+    return if !@enabled
 
     uri = URI.parse(@webhook_url)
     http = Net::HTTP.new(uri.host, uri.port)
@@ -54,7 +54,7 @@ class DiscordWebhook
 
     response = http.request(request)
 
-    unless response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPNoContent)
+    if !(response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPNoContent))
       puts "[Discord] Webhook送信失敗: #{response.code} #{response.message}"
     end
   rescue StandardError => e
@@ -79,12 +79,12 @@ class LogWatcher
     @running = true
 
     loop do
-      break unless @running
+      break if !@running
 
       until File.exist?(@log_path)
         puts "[LogWatcher] ログファイル待機中: #{@log_path}"
         sleep 1
-        return unless @running
+        return if !@running
       end
 
       current_inode = File.stat(@log_path).ino

--- a/scripts/discord_notify.rb
+++ b/scripts/discord_notify.rb
@@ -176,6 +176,11 @@ class DiscordNotifier
     puts '⏳ Minecraftサーバーの起動を待機中...'
 
     MAX_RETRIES.times do |i|
+      if @stopping
+        puts '停止シグナルを受信したため待機を中断します'
+        exit 1
+      end
+
       rcon = RconClient.new(RCON_HOST, RCON_PORT, RCON_PASSWORD)
       rcon.connect
 
@@ -186,6 +191,11 @@ class DiscordNotifier
     rescue RconClient::ConnectionError => e
       puts "   試行 #{i + 1}/#{MAX_RETRIES}: #{e.message}"
       sleep RETRY_INTERVAL
+      if @stopping
+        rcon&.disconnect
+        puts '停止シグナルを受信したため待機を中断します'
+        exit 1
+      end
     rescue RconClient::AuthenticationError => e
       puts "❌ 認証失敗: #{e.message}"
       exit 1

--- a/scripts/discord_notify.rb
+++ b/scripts/discord_notify.rb
@@ -198,7 +198,7 @@ class DiscordNotifier
     MAX_RETRIES.times do |i|
       if @stopping
         puts '停止シグナルを受信したため待機を中断します'
-        exit 1
+        exit 0
       end
 
       rcon = RconClient.new(RCON_HOST, RCON_PORT, RCON_PASSWORD)
@@ -214,7 +214,7 @@ class DiscordNotifier
       if @stopping
         rcon&.disconnect
         puts '停止シグナルを受信したため待機を中断します'
-        exit 1
+        exit 0
       end
     rescue RconClient::AuthenticationError => e
       puts "❌ 認証失敗: #{e.message}"

--- a/test/test_log_rotation.sh
+++ b/test/test_log_rotation.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# ログローテーション検証スクリプト
+
+set -e
+
+# serverコンテナ内のパス（書き込み可能）
+LOG_FILE="/data/logs/latest.log"
+# 操作はserverコンテナで、監視結果はdiscord-notifyで確認
+WRITE_SERVICE="server"
+
+echo "=== ログローテーション検証スクリプト ==="
+echo
+
+# 1. 初期状態確認
+echo "1. 初期i-node確認"
+docker compose exec $WRITE_SERVICE stat -c "i-node: %i" $LOG_FILE
+
+sleep 2
+
+# 2. ログに参加イベントを書き込み（ローテーション前）
+echo "2. ローテーション前のイベント書き込み"
+docker compose exec $WRITE_SERVICE sh -c "echo '[$(date +%H:%M:%S)] [Server thread/INFO]: PlayerBefore joined the game' >> $LOG_FILE"
+
+sleep 2
+
+# 3. ログローテーション実行
+echo "3. ログローテーション実行"
+docker compose exec $WRITE_SERVICE sh -c "
+  mv $LOG_FILE ${LOG_FILE}.old
+  touch $LOG_FILE
+"
+
+sleep 2
+
+# 4. 新しいi-node確認
+echo "4. 新しいi-node確認"
+docker compose exec $WRITE_SERVICE stat -c "i-node: %i" $LOG_FILE
+
+sleep 2
+
+# 5. ログに参加イベントを書き込み（ローテーション後）
+echo "5. ローテーション後のイベント書き込み"
+docker compose exec $WRITE_SERVICE sh -c "echo '[$(date +%H:%M:%S)] [Server thread/INFO]: PlayerAfter joined the game' >> $LOG_FILE"
+
+echo
+echo "=== 検証完了 ==="
+echo "discord-notifyのログで以下を確認してください："
+echo "  - '[LogWatcher] ログローテーションを検出しました' が表示される"
+echo "  - PlayerBefore と PlayerAfter の両方が検出される"


### PR DESCRIPTION
## 概要
Discord通知サービスにログローテーション検出機能を追加し、日付が変わってログファイルが切り替わっても継続して監視できるように対応した。

Closes #9

## 背景
Minecraftサーバーは日付が変わると`latest.log`を圧縮し、新しいファイルを作成している。これにより、従来の実装ではファイルハンドルが古いファイルを指したままとなり、新しいイベントを検出できずにいた。

## 変更内容

###  ログローテーション検出機能の追加
- **i-node番号による検出**: ログファイルのi-node番号を監視し、ファイルが入れ替わったことを検出
- **自動再接続**: ローテーション検出時に古いファイルハンドルをクローズし、新しいログファイルを自動的に開き直す
- **エラーハンドリング**: ローテーション中にファイルが一時的に存在しない場合も適切に処理

**実装の詳細:**
```ruby
# ファイルを開く前にi-nodeを記録
current_inode = File.stat(@log_path).ino

# 読み取りループ内でi-nodeの変化をチェック
new_inode = File.stat(@log_path).ino
if new_inode != current_inode
  puts '[LogWatcher] ログローテーションを検出しました'
  break  # ファイルを閉じて再度開き直す
end
```

###  停止シグナルのハンドリング改善
- `wait_for_server`メソッド内で`@stopping`フラグをチェック
- TERM/INTシグナル受信時に即座に待機処理を中断し、クリーンに終了
- リトライループ中の停止にも対応

###  テストスクリプトの追加
- `test_log_rotation.sh`: ログローテーションを手動でシミュレートする検証スクリプト
- i-node番号の変化を確認し、ローテーション前後でイベント検出が継続することを検証

## 影響範囲
- `scripts/discord_notify.rb`: LogWatcherクラスとDiscordNotifierクラスの改修
- 新規ファイル: `test_log_rotation.sh`（検証用、本番には影響なし）


## テスト事項

- [x] i-node番号がローテーション前後で変化することを確認
- [x] ローテーション前のイベント（PlayerBefore）を検出
- [x] ローテーション後のイベント（PlayerAfter）を検出
- [x] Discord通知に両方のイベントが届くことを確認
- [x] 実運用において日付を跨いだ通知ができることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ログローテーション検出機能を追加しました。  
* **テスト**
  * ログローテーション挙動を検証する自動化テストを追加しました。  
* **バグ修正**
  * サーバー起動やログ監視中の停止シグナル処理を改善し、早期終了とクリーンな後片付けに対応しました。  
  * 監視のログローテーション耐性と一時的なファイル欠如時のエラーハンドリングを強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->