### PR TITLE
JourneyMapのWorld UUID消失を防止

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,51 @@
+# セッション引き継ぎドキュメント
+
+## 作業ブランチ
+
+`fix/journeymap-world-uuid` (PRを作成済み、検証運用中)
+
+## 行った作業の要約
+
+### 問題: JourneyMapの探索記録がリセットされる
+
+サーバー再起動時や別の人がホストした際に、JourneyMapのマップ探索記録が消える問題を調査・修正した。
+
+### 調査の流れ
+
+1. `data/journeymap/` にはサーバー側の設定ファイルのみで、マップタイルはクライアント側に保存されることを確認
+2. クライアント側のJourneyMapログから、マップデータのフォルダが `World UID` で識別されていることを特定
+3. `world/data/WorldUUID.dat` にWorld UIDが格納されていることを発見（NBTファイルをpython nbtライブラリで解析）
+4. このファイルはJourneyMapサーバーMODがForgeのSavedData APIで生成するもので、ワールド保存時にディスクに書き込まれる
+5. `docker compose down` のデフォルト `stop_grace_period`（10秒）ではMOD入りForgeサーバーのシャットダウンが間に合わず、WorldUUID.datが保存されないまま強制終了されていた
+
+### 修正内容 (`compose.yml`)
+
+- `stop_grace_period: 120s` を追加: SIGTERM→SIGKILLの猶予を120秒に延長
+- `EXEC_DIRECTLY: "true"` を追加: SIGTERMをJavaプロセスに直接送信
+
+## 決定事項
+
+- mainブランチでの直接作業は避け、ブランチを切って作業する運用
+- 本番データの破損リスクを避けるため、テスト時は `start-server.sh dev` で開発環境を使用
+- コミット・PRはユーザー本人が手動で行う
+
+## 未完了タスク
+
+- [ ] **検証運用**: 修正後のサーバーでJourneyMapのWorld UIDが再起動後も維持されるか確認（`World UID is set to:` ログで確認）
+- [ ] **異なるホストでの検証**: 別の人がホストした場合にもUUIDが維持されるか確認
+- [ ] **PRのマージ**: 検証完了後にmainへマージ
+
+## 陥った落とし穴と学んだ教訓
+
+### JourneyMapのデータ構造の誤解に注意
+- `data/journeymap/` はサーバー設定のみ。実際のマップ探索データはクライアント側の `.minecraft/journeymap/data/mp/` に保存される
+- マップフォルダの識別は `world/data/WorldUUID.dat` のUUIDに基づく（IPアドレスではない、`useWorldId: true` の場合）
+
+### WorldUUID.datの所在
+- `world/data/WorldUUID.dat` はForge/Minecraft標準のファイルではなく、JourneyMapサーバーMODがSavedData APIで生成するファイル
+- level.datにはWorld UUIDは格納されていない（python nbtライブラリで確認済み）
+
+### Dockerのgraceful shutdown
+- `docker compose down` のデフォルトは10秒でSIGKILL。MODサーバーには短すぎる
+- `EXEC_DIRECTLY: true` がないと、itzgイメージのラッパースクリプトがSIGTERMを受け取り、Javaプロセスに適切に伝播しない可能性がある
+- SavedDataファイルはワールド保存時にのみディスクに書き込まれるため、シャットダウンが不完全だとファイルが失われる

--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,7 @@ services:
     container_name: mc_server
     image: itzg/minecraft-server
     restart: unless-stopped
+    stop_grace_period: 120s
     tty: true
     stdin_open: true
     ports:
@@ -36,6 +37,7 @@ services:
       SERVER_NAME: "MyServer"
       SERVER_PORT: "25565"
       ENABLE_JMX: "false"
+      EXEC_DIRECTLY: "true"
       ENABLE_RCON: "true"
       RCON_PASSWORD: "${RCON_PASSWORD:-minecraft}"
       BROADCAST_CONSOLE_TO_OPS: "true"

--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,7 @@ services:
       SERVER_NAME: "MyServer"
       SERVER_PORT: "25565"
       ENABLE_JMX: "false"
-      EXEC_DIRECTLY: "true"
+      STOP_DURATION: "110"
       ENABLE_RCON: "true"
       RCON_PASSWORD: "${RCON_PASSWORD:-minecraft}"
       BROADCAST_CONSOLE_TO_OPS: "true"


### PR DESCRIPTION
## 原因判明につきclose
JourneyMapクライアント側のデータ保存パスの仕様が原因:

| 接続方法 | 保存パス | ホスト変更時 |
|---|---|---|
| ダイレクト接続 | `Minecraft~_<UUID>` | UUIDが同じなので影響なし |
| サーバの追加(プロファイル) | `<サーバ名>_<UUID>` | サーバ名が変わると別フォルダ → リセット |


ホストごとに別のサーバプロファイルを作成していたクライアント環境で、サーバ名がパスに含まれるため別フォルダに保存され、探索記録がリセットされたように見えていた。
---


## 概要
  - stop_grace_period: 120s を追加し、MODサーバーのシャットダウンに十分な時間を確保
  - EXEC_DIRECTLY: true を追加し、SIGTERMをJavaプロセスに直接送信して確実なシャットダウンシーケンスを実行

 
 ## 既知の問題
  サーバーを再起動したり、別の人がホストした際に、JourneyMapのマップ探索記録（どこを歩いたかの地図データ）がリセットされる事象が発生していた。

 ### 原因
  JourneyMapはクライアントサイドMODであり、マップタイル（探索した地図画像）は各プレイヤーのローカルPCに保存される。保存先フォルダの識別には、サーバー側の world/data/WorldUUID.dat に格納されたUUIDが使われる。

  (クライアント側)
` .minecraft/journeymap/data/mp/Minecraft~_<WorldUUID>/`
  このWorldUUID.datはJourneyMapサーバーMODがForgeのSavedData APIを通じて生成・保存するファイルで、ワールド保存時にディスクに書き込まれる。しかしdocker compose down のデフォルトの stop_grace_period は10秒しかなく、MOD入りForgeサーバーのシャットダウンにはこれでは不十分なケースがある。
タイムアウトするとDockerはSIGKILLでコンテナを強制終了するため、ワールドの保存処理が完了せず WorldUUID.dat がディスクに書き込まれない。
  結果として、次回起動時にJourneyMapが新しいUUIDを生成し、クライアント側では別のフォルダにマップデータが保存されるため、以前の探索記録が見えなくなっていた。


### 対策
  - stop_grace_period: 120s: SIGTERMからSIGKILLまでの猶予を120秒に延長し、Forgeサーバーがワールドデータを確実に保存できるようにする
  - EXEC_DIRECTLY: true: itzg/minecraft-serverイメージのラッパースクリプトを介さず、SIGTERMを直接Javaプロセスに送信する。これによりMinecraftサーバーが正常なシャットダウンシーケンス（/stop コマンド相当）を実行できる

## テスト項目
- [ ] サーバー起動→探索→停止→再起動で、JourneyMapログの World UID is set to: が同一UUIDであることを確認
- [ ]  異なるホストでの起動でもUUIDが維持されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * サーバーの停止猶予時間を延長し、より穏やかなシャットダウンを実現
  * 停止挙動を制御する環境変数を追加

* **ドキュメント**
  * 引き継ぎ用ドキュメントを追加（調査内容、修正点、残タスク、得られた知見を記載）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->