### PR TITLE
enhance: 同一ホスト時のダウンロード時間の短縮

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,11 +183,11 @@ docker compose run --rm sync-init ruby /app/sync.rb upload
 
 - **frozen string literal:** すべての Ruby ファイルは `# frozen_string_literal: true` で始める。
 - **クラスベースのアーキテクチャ:** 各スクリプトは役割が明確なクラスを 1 つ以上公開する。
+- **Ruby 慣用表現に従う:** `if !condition` の代わりに `unless condition` を使う。ただし `||` や `&&` を含む複合条件では、ド・モルガン変換による可読性低下を避けるため `if !` を許容する。
 - **コメントは日本語** — 意図的なものであり、維持すること。
 - **コンソール出力に絵文字を使用** — 視覚的な状態把握のために使用しているため、このスタイルを維持すること。
 - **エラーハンドリング:** ドメインエラーにはカスタム例外クラスを使用。R2 操作では `Aws::S3::Errors::ServiceError` を rescue する。
 - **テストフレームワークなし:** テストは Docker 環境を直接操作する bash スクリプト (`test/test_log_rotation.sh`) 1 つのみ。
-- **否定条件に `unless` を使用しない** — `unless bool` ではなく `if !bool` スタイルを使用すること (コミット `b324b63` 参照)。
 - **所有権:** Docker ボリューム内のワールドデータファイルは必ず UID/GID 1000 で所有すること。
 
 ---

--- a/compose.yml
+++ b/compose.yml
@@ -16,6 +16,7 @@ services:
       R2_BUCKET_NAME: ${R2_BUCKET_NAME}
       R2_ENDPOINT: ${R2_ENDPOINT}
       LOCAL_DATA_DIR: ${LOCAL_DATA_DIR:-./data}
+      HOST_DISPLAY_NAME: ${HOST_DISPLAY_NAME:-}
     command: ruby sync.rb init
     restart: "no"
 
@@ -100,6 +101,7 @@ services:
       R2_BUCKET_NAME: ${R2_BUCKET_NAME}
       R2_ENDPOINT: ${R2_ENDPOINT}
       LOCAL_DATA_DIR: ${LOCAL_DATA_DIR:-./data}
+      HOST_DISPLAY_NAME: ${HOST_DISPLAY_NAME:-}
     command: ruby sync.rb shutdown
     restart: "no"
     profiles:

--- a/scripts/discord_notify.rb
+++ b/scripts/discord_notify.rb
@@ -40,7 +40,7 @@ class DiscordWebhook
   def send(payload, log_message: nil)
     puts "[Discord] #{log_message || payload.to_json}"
 
-    return if !@enabled
+    return unless @enabled
 
     uri = URI.parse(@webhook_url)
     http = Net::HTTP.new(uri.host, uri.port)
@@ -54,7 +54,7 @@ class DiscordWebhook
 
     response = http.request(request)
 
-    if !(response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPNoContent))
+    unless response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPNoContent)
       puts "[Discord] Webhook送信失敗: #{response.code} #{response.message}"
     end
   rescue StandardError => e
@@ -79,12 +79,12 @@ class LogWatcher
     @running = true
 
     loop do
-      break if !@running
+      break unless @running
 
       until File.exist?(@log_path)
         puts "[LogWatcher] ログファイル待機中: #{@log_path}"
         sleep 1
-        return if !@running
+        return unless @running
       end
 
       begin
@@ -279,7 +279,7 @@ class DiscordNotifier
 
   def shutdown
     return if @shutdown_sent
-    return if !@rcon
+    return unless @rcon
 
     @shutdown_sent = true
     @webhook.send({

--- a/scripts/sync.rb
+++ b/scripts/sync.rb
@@ -21,6 +21,7 @@ LOCAL_DATA_DIR = ENV.fetch('LOCAL_DATA_DIR', './data')
 
 LOCK_FILE_KEY = 'server.lock'
 DATA_ARCHIVE_KEY = 'server-data.tar.gz'
+SYNC_HEADER_KEY = 'sync-header.json'
 
 # =============================================================================
 # R2同期クラス
@@ -37,6 +38,8 @@ class R2Sync
       force_path_style: true
     )
     @hostname = Socket.gethostname
+    @host_display_name = ENV.fetch('HOST_DISPLAY_NAME', nil)
+    @host_display_name = nil if @host_display_name&.empty?
   end
 
   # 必須環境変数のバリデーション
@@ -65,6 +68,45 @@ class R2Sync
     JSON.parse(response.body.read)
   rescue Aws::S3::Errors::NoSuchKey
     nil
+  end
+
+  # 同期ヘッダファイルの確認
+  # 最後にアップロードしたホストの情報を返す。存在しない場合はnilを返す
+  def check_sync_header
+    response = @s3_client.get_object(
+      bucket: R2_BUCKET_NAME,
+      key: SYNC_HEADER_KEY
+    )
+    JSON.parse(response.body.read)
+  rescue Aws::S3::Errors::NoSuchKey
+    nil
+  rescue Aws::S3::Errors::ServiceError => e
+    puts "⚠️  同期ヘッダの確認に失敗しました: #{e.message}"
+    nil
+  end
+
+  # 同期ヘッダファイルをR2にアップロード
+  # アップロード完了後にホスト識別情報を記録する
+  def upload_sync_header
+    if !@host_display_name
+      puts 'ℹ️  HOST_DISPLAY_NAMEが未設定のため、同期ヘッダのアップロードをスキップします'
+      return
+    end
+
+    header_data = {
+      'host_display_name' => @host_display_name,
+      'timestamp' => Time.now.utc.iso8601
+    }
+
+    @s3_client.put_object(
+      bucket: R2_BUCKET_NAME,
+      key: SYNC_HEADER_KEY,
+      body: JSON.pretty_generate(header_data),
+      content_type: 'application/json'
+    )
+    puts "✅ 同期ヘッダをアップロードしました (ホスト: #{@host_display_name})"
+  rescue Aws::S3::Errors::ServiceError => e
+    puts "⚠️  警告: 同期ヘッダのアップロードに失敗しました: #{e.message}"
   end
 
   # ロックファイルの作成
@@ -198,23 +240,52 @@ class R2Sync
     puts '✅ サーバーデータをR2にアップロードしました'
   end
 
-  # 初期化処理: ロック取得 → データダウンロード
+  # 初期化処理: ロック取得 → ヘッダ確認 → データダウンロード（必要な場合のみ）
   def sync_init
     puts '🚀 サーバー同期を初期化中...'
     create_lock
-    download_data
+    sync_header = check_sync_header
+    if should_skip_download?(sync_header)
+      puts "⏭️  前回の起動者と同一ホストのため、ダウンロードをスキップします (ホスト: #{@host_display_name})"
+    else
+      download_data
+    end
     puts '✅ 同期の初期化が完了しました'
   end
 
-  # シャットダウン処理: データアップロード → ロック解放
+  # シャットダウン処理: データアップロード → ヘッダアップロード → ロック解放
   def sync_shutdown
     puts '🔄 サーバー同期をシャットダウン中...'
     upload_data
+    upload_sync_header
     release_lock
     puts '✅ 同期のシャットダウンが完了しました'
   end
 
   private
+
+  # ダウンロードをスキップできるかどうかを判定する
+  # 同期ヘッダのhost_display_nameが現在のホストと一致し、ローカルデータが存在する場合にtrueを返す
+  def should_skip_download?(sync_header)
+    # HOST_DISPLAY_NAMEが未設定の場合はスキップしない
+    if !@host_display_name
+      return false
+    end
+
+    # 同期ヘッダが存在しない場合（初回起動・レガシー環境）はスキップしない
+    if !sync_header
+      return false
+    end
+
+    # ローカルデータディレクトリが存在しないか空の場合はスキップしない
+    local_data_path = File.expand_path(LOCAL_DATA_DIR)
+    if !Dir.exist?(local_data_path) || Dir.empty?(local_data_path)
+      return false
+    end
+
+    # ホスト識別子が一致する場合のみスキップ
+    sync_header['host_display_name'] == @host_display_name
+  end
 
   # tar.gzアーカイブを作成
   def create_tar_gz(source_dir, archive_path)
@@ -254,6 +325,7 @@ def print_usage
   puts '  lock         - サーバーロックの取得のみ'
   puts '  unlock       - サーバーロックの解放のみ'
   puts '  check-lock   - 現在のロック状態を確認'
+  puts '  check-header - 同期ヘッダの確認'
   exit 1
 end
 
@@ -284,6 +356,15 @@ def main
       puts "   開始時刻: #{lock['timestamp'] || 'unknown'}"
     else
       puts '🔓 サーバーはロックされていません'
+    end
+  when 'check-header'
+    header = sync.check_sync_header
+    if header
+      puts '📋 同期ヘッダ情報:'
+      puts "   最終アップロードホスト: #{header['host_display_name'] || 'unknown'}"
+      puts "   アップロード時刻: #{header['timestamp'] || 'unknown'}"
+    else
+      puts 'ℹ️  同期ヘッダが存在しません'
     end
   else
     puts "❌ 不明なコマンド: #{command}"

--- a/scripts/sync.rb
+++ b/scripts/sync.rb
@@ -88,7 +88,7 @@ class R2Sync
   # 同期ヘッダファイルをR2にアップロード
   # アップロード完了後にホスト識別情報を記録する
   def upload_sync_header
-    if !@host_display_name
+    unless @host_display_name
       puts 'ℹ️  HOST_DISPLAY_NAMEが未設定のため、同期ヘッダのアップロードをスキップします'
       return
     end
@@ -268,20 +268,14 @@ class R2Sync
   # 同期ヘッダのhost_display_nameが現在のホストと一致し、ローカルデータが存在する場合にtrueを返す
   def should_skip_download?(sync_header)
     # HOST_DISPLAY_NAMEが未設定の場合はスキップしない
-    if !@host_display_name
-      return false
-    end
+    return false unless @host_display_name
 
     # 同期ヘッダが存在しない場合（初回起動・レガシー環境）はスキップしない
-    if !sync_header
-      return false
-    end
+    return false unless sync_header
 
     # ローカルデータディレクトリが存在しないか空の場合はスキップしない
     local_data_path = File.expand_path(LOCAL_DATA_DIR)
-    if !Dir.exist?(local_data_path) || Dir.empty?(local_data_path)
-      return false
-    end
+    return false if !Dir.exist?(local_data_path) || Dir.empty?(local_data_path)
 
     # ホスト識別子が一致する場合のみスキップ
     sync_header['host_display_name'] == @host_display_name


### PR DESCRIPTION
## 概要
サーバー同期スクリプトにマルチホスト対応機能を追加しました。同期ヘッダファイル（sync-header.json）を導入し、前回のアップロード元ホストを記録することで、同一ホストからの起動時に不要なダウンロードをスキップできるようにしました。

## 背景・動機
- 複数のホストから同じサーバーデータを管理する場合、毎回全データをダウンロードするのは非効率
- 同一ホストからの連続起動時は、ローカルデータが既に最新であるため、ダウンロードをスキップしたい
- ホスト識別情報を記録することで、ホスト間のデータ同期状態を把握できるようにしたい

## 新規追加ファイル
なし

## 変更内容

### scripts/sync.rb
- **定数追加**: `SYNC_HEADER_KEY = 'sync-header.json'` を追加
- **初期化処理**: `@host_display_name` インスタンス変数を追加し、環境変数 `HOST_DISPLAY_NAME` から取得
- **新規メソッド `check_sync_header`**: R2から同期ヘッダを取得し、最後のアップロード元ホスト情報を返す
- **新規メソッド `upload_sync_header`**: 現在のホスト識別情報とタイムスタンプをR2にアップロード
- **新規メソッド `should_skip_download?`**: ダウンロードをスキップすべきかを判定
  - `HOST_DISPLAY_NAME` が未設定の場合はスキップしない
  - 同期ヘッダが存在しない場合（初回起動）はスキップしない
  - ローカルデータが存在しない場合はスキップしない
  - ホスト識別子が一致する場合のみスキップ
- **`sync_init` メソッド**: 同期ヘッダを確認し、条件に応じてダウンロードをスキップ
- **`sync_shutdown` メソッド**: シャットダウン時に同期ヘッダをアップロード
- **新規コマンド `check-header`**: 同期ヘッダの内容を確認できるコマンドを追加

### compose.yml
- **環境変数追加**: `HOST_DISPLAY_NAME` を init・shutdown サービスに追加
  - デフォルト値は空文字列（未設定状態）

## 技術的な判断
- **ホスト識別方法**: `Socket.gethostname` ではなく環境変数 `HOST_DISPLAY_NAME` を使用することで、コンテナ環境での柔軟な識別を実現
- **空文字列の処理**: `@host_display_name&.empty?` で空文字列を `nil` に統一し、未設定状態を明確に区別
- **エラーハンドリング**: S3操作時の `NoSuchKey` と一般的な `ServiceError` を分けて処理し、初回起動時の動作を保証
- **スキップ判定の厳密性**: 複数の条件をすべて満たす場合のみスキップすることで、データ不整合を防止

## テスト確認項目
- 初回起動

https://claude.ai/code/session_01GzGZoV4xC6H6XxRDj9JmTk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ホスト間の同期を追跡する同期ヘッダー機能を追加しました。
  * 最新の同期ヘッダー情報を表示する新しい「check-header」コマンドを追加しました。

* **改善**
  * 初期化時にリモートの同期状態を確認し、必要に応じてデータダウンロードをスキップするスマート同期ロジックを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->